### PR TITLE
CodeEdit scroll limit

### DIFF
--- a/Scripts/camera.gd
+++ b/Scripts/camera.gd
@@ -20,6 +20,9 @@ var d := 0.0;
 var radius := 4.0
 var speed := 2.0
 
+func _ready() -> void:
+	limit_right = code.size.x
+
 func _process(delta: float) -> void:
 	d += delta;
 


### PR DESCRIPTION
**Summary**
> Simple ready function on the Camera node setting the limit it can scroll to the right to the size of the CodeEdit node's size x property. This allows users to continue scrolling in the editor without the camera scrolling past the editor.

**Testing Evidence**
> ![image](https://github.com/face-hh/griddycode/assets/59128578/c1938328-4313-43c6-9826-0160e19e3ff7)
> I'm scrolled as far right as I can be, the editor allows me to continue scrolling on my string that is over 1600 characters long.
