### PR TITLE
Fixed camera issues when line count is over 1652

### DIFF
--- a/Scenes/editor.tscn
+++ b/Scenes/editor.tscn
@@ -86,6 +86,7 @@ generateHighlightedText();
 context_menu_enabled = false
 scroll_smooth = true
 scroll_v_scroll_speed = 150.0
+scroll_fit_content_height = true
 minimap_draw = true
 caret_blink = true
 syntax_highlighter = SubResource("CodeHighlighter_p2au2")


### PR DESCRIPTION
The CodeEditor node now fits the content size, so that the camera never goes out of bounds