### PR TITLE
Fix crt and vhs shader brightness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 .godot/
 Tools/target
 Builds/*
-addons/discord-sdk-gd/bin/windows/~discord_game_sdk_binding_debug.dll
-*.dll

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .godot/
 Tools/target
 Builds/*
+addons/discord-sdk-gd/bin/windows/~discord_game_sdk_binding_debug.dll
+*.dll

--- a/Shaders/vhs_and_crt.gdshader
+++ b/Shaders/vhs_and_crt.gdshader
@@ -37,7 +37,7 @@ uniform float noise_speed = 5.0; // There is a movement in the noise pattern tha
 uniform float static_noise_intensity : hint_range(0.0, 1.0) = 0.06;
 
 uniform float aberration : hint_range(-1.0, 1.0) = 0.016; // Chromatic aberration, a distortion on each color channel.
-uniform float brightness = 6; // When adding scanline gaps and grille the image can get very dark. Brightness tries to compensate for that.
+uniform float brightness = 1; // When adding scanline gaps and grille the image can get very dark. Brightness tries to compensate for that.
 uniform bool discolor = false; // Add a discolor effect simulating a VHS
 
 uniform float warp_amount :hint_range(0.0, 5.0) = 1.0; // Warp the texture edges simulating the curved glass of a CRT monitor or old TV.


### PR DESCRIPTION
Just changed the brightness value, makes it look slightly worse on GitHub dark, but much better on all other themes.
Might be worth trying different brightness values and adjusting the pixel sizes for the shader, as when it is not overwhelmed with brightness it does look a little worse. Over around brightness 1.5 makes line numbers unreadable for GitHub light theme, however.

Github Dark Before:
![image](https://github.com/face-hh/griddycode/assets/80719694/daa128e4-feda-4bab-9919-8e1a7d5b8582)

Github Dark After:
![image](https://github.com/face-hh/griddycode/assets/80719694/d31c45f8-8e43-438f-b4ed-150895fe5562)

One Dark Pro Darker Before:
![image](https://github.com/face-hh/griddycode/assets/80719694/e98ef420-da3b-4ba0-9485-7d7e4d44e189)

One Dark Pro Darker After:
![image](https://github.com/face-hh/griddycode/assets/80719694/78542bb2-9e09-4028-aa65-19d48fd275b6)

Github Light Before:
![image](https://github.com/face-hh/griddycode/assets/80719694/8ecc94b4-c458-4c64-91c0-2f4a32492790)

Github Light After:
![image](https://github.com/face-hh/griddycode/assets/80719694/a8a7a313-434b-4827-8372-46fe3a9cc34b)

Nord Before:
![image](https://github.com/face-hh/griddycode/assets/80719694/6b95fa4b-7e36-43f5-af2a-fe9859d9ccb7)

Nord After:
![image](https://github.com/face-hh/griddycode/assets/80719694/6222982e-49b2-4201-ad6d-81a551f2a149)
