### PR TITLE
Create rs.lua

### DIFF
--- a/Lua/Plugins/rs.lua
+++ b/Lua/Plugins/rs.lua
@@ -1,0 +1,12 @@
+highlight("const", "reserved")
+highlight("fn", "reserved")
+highlight("let", "reserved")
+highlight("mut", "reserved")
+highlight("+", "operator")
+highlight("-", "operator")
+highlight("*", "operator")
+highlight("/", "operator")
+highlight("%", "operator")
+
+
+add_comment("add some raw pointers trust")


### PR DESCRIPTION
basic rust syntax highlighting (better than nothing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added syntax highlighting support for a Rust-like language, including reserved words and operators.
	- Introduced a new comment string for this language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->