### PR TITLE
Create txt.lua

### DIFF
--- a/Lua/Plugins/txt.lua
+++ b/Lua/Plugins/txt.lua
@@ -1,0 +1,1 @@
+-- Nothing, because nothing is highlighted in `.txt` files.


### PR DESCRIPTION
`.txt` files have unnecessary predictions/highlighting that nobody wants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a note indicating that no syntax highlighting is applied to `.txt` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->